### PR TITLE
Use less flaky mirrors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM debian:stretch
 
+# The default mirrors are too flaky to run reliably in CI.
+RUN sed -E \
+    '/security\.debian/! s@http://[^/]+/@http://mirrors.kernel.org/@' \
+    -i /etc/apt/sources.list
+
 RUN apt-get update  \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \

--- a/ci/docker
+++ b/ci/docker
@@ -8,7 +8,7 @@ chmod 1777 /tmp
 if grep -qE '\<lucid\>' /etc/apt/sources.list; then
     # lucid was archived, breaking the base image
     # https://github.com/docker-library/official-images/issues/1902
-    sed -i 's/archive\.ubuntu\.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+    sed -i 's@archive\.ubuntu\.com@archive.kernel.org/ubuntu-archive@g' /etc/apt/sources.list
 
     apt-get update
     apt-get install -y --no-install-recommends python-software-properties
@@ -17,6 +17,11 @@ if grep -qE '\<lucid\>' /etc/apt/sources.list; then
     add-apt-repository ppa:fkrull/deadsnakes
     # for zsh 5 backport (lucid's zsh segfaults)
     add-apt-repository ppa:blueyed/ppa
+else
+    # The default mirrors are too flaky to run reliably in CI.
+    sed -E \
+        '/security\.debian/! s@http://[^/]+/@http://mirrors.kernel.org/@' \
+        -i /etc/apt/sources.list
 fi
 
 apt-get update


### PR DESCRIPTION
The default debian mirrors (deb. or httpredir.) are just too flaky and fail on CI frequently. This generates noise which we can't really do anything about, except to use different mirrors :(