### PR TITLE
Stop building for lucid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: python
 
 env:
     - MAKE_TARGET=test
-    - MAKE_TARGET=itest_lucid
     - MAKE_TARGET=itest_trusty
     - MAKE_TARGET=itest_xenial
     - MAKE_TARGET=itest_jessie

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
     - docker
 
 language: python
+python: '3.6'
 
 env:
     - MAKE_TARGET=test

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,11 @@ builddeb-docker: docker-builder-image
 	mkdir -p dist
 	docker run -v $(PWD):/mnt $(DOCKER_BUILDER)
 
-ITEST_TARGETS = itest_lucid itest_trusty itest_xenial itest_jessie itest_stretch
+ITEST_TARGETS = itest_trusty itest_xenial itest_jessie itest_stretch
 
 .PHONY: itest $(ITEST_TARGETS)
 itest: $(ITEST_TARGETS)
 
-itest_lucid: _itest-ubuntu-lucid
 itest_trusty: _itest-ubuntu-trusty
 itest_xenial: _itest-ubuntu-xenial
 itest_jessie: _itest-debian-jessie

--- a/ci/docker
+++ b/ci/docker
@@ -5,24 +5,10 @@ set -o pipefail
 # We need to set standard /tmp permissions since it's a Docker volume.
 chmod 1777 /tmp
 
-if grep -qE '\<lucid\>' /etc/apt/sources.list; then
-    # lucid was archived, breaking the base image
-    # https://github.com/docker-library/official-images/issues/1902
-    sed -i 's@archive\.ubuntu\.com@archive.kernel.org/ubuntu-archive@g' /etc/apt/sources.list
-
-    apt-get update
-    apt-get install -y --no-install-recommends python-software-properties
-
-    # for python3.4 backport
-    add-apt-repository ppa:fkrull/deadsnakes
-    # for zsh 5 backport (lucid's zsh segfaults)
-    add-apt-repository ppa:blueyed/ppa
-else
-    # The default mirrors are too flaky to run reliably in CI.
-    sed -E \
-        '/security\.debian/! s@http://[^/]+/@http://mirrors.kernel.org/@' \
-        -i /etc/apt/sources.list
-fi
+# The default mirrors are too flaky to run reliably in CI.
+sed -E \
+    '/security\.debian/! s@http://[^/]+/@http://mirrors.kernel.org/@' \
+    -i /etc/apt/sources.list
 
 apt-get update
 apt-get install -y --no-install-recommends \

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,3 @@ override_dh_auto_test:
 override_dh_install:
 	mkdir -p debian/aactivator/usr/bin
 	cp aactivator.py debian/aactivator/usr/bin/aactivator
-
-override_dh_builddeb:
-	# Use gzip instead of xz to support ubuntu:lucid.
-	dh_builddeb -- -Zgzip

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py36
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
bootstrap.pypa.io no longer supports TLS < 1.2, let's just drop lucid.