### PR TITLE
Migrate from autopep8-wrapper to mirrors-autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
+repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: v0.9.1
+    rev: v2.0.0
     hooks:
-    -   id: autopep8-wrapper
     -   id: check-docstring-first
     -   id: check-json
     -   id: check-yaml
@@ -9,7 +9,11 @@
     -   id: end-of-file-fixer
     -   id: flake8
     -   id: trailing-whitespace
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.1
+    hooks:
+    -   id: autopep8
 -   repo: https://github.com/asottile/reorder_python_imports
-    sha: v0.3.5
+    rev: v1.3.2
     hooks:
     -   id: reorder-python-imports


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos