### PR TITLE
Fix itest_xenial failure

### DIFF
--- a/ci/docker
+++ b/ci/docker
@@ -20,7 +20,8 @@ apt-get install -y --no-install-recommends \
     python3-dev \
     zsh
 
-curl https://bootstrap.pypa.io/get-pip.py | python3
+# TODO: Remove python3.5 constraint on get-pip.py once xenial is dumped
+curl https://bootstrap.pypa.io/3.5/get-pip.py | python3
 gdebi -n /mnt/dist/*.deb
 pip install -r /mnt/requirements-dev.txt
 pip install /mnt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from py._path.local import LocalPath
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def cwd():
     with LocalPath('/').as_cwd():
         yield


### PR DESCRIPTION
Fixes
```
[2021-02-03T11:02:08.415Z] + curl https://bootstrap.pypa.io/get-pip.py

[2021-02-03T11:02:08.415Z] + python3

[2021-02-03T11:02:08.415Z]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current

[2021-02-03T11:02:08.415Z]                                  Dload  Upload   Total   Spent    Left  Speed

[2021-02-03T11:02:08.978Z] 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 1884k  100 1884k    0     0  5912k      0 --:--:-- --:--:-- --:--:-- 5926k

[2021-02-03T11:02:09.235Z] Traceback (most recent call last):

[2021-02-03T11:02:09.235Z]   File "<stdin>", line 24244, in <module>

[2021-02-03T11:02:09.235Z]   File "<stdin>", line 199, in main

[2021-02-03T11:02:09.235Z]   File "<stdin>", line 82, in bootstrap

[2021-02-03T11:02:09.235Z]   File "<frozen importlib._bootstrap>", line 969, in _find_and_load

[2021-02-03T11:02:09.235Z]   File "<frozen importlib._bootstrap>", line 954, in _find_and_load_unlocked

[2021-02-03T11:02:09.235Z]   File "<frozen importlib._bootstrap>", line 896, in _find_spec

[2021-02-03T11:02:09.235Z]   File "<frozen importlib._bootstrap_external>", line 1139, in find_spec

[2021-02-03T11:02:09.235Z]   File "<frozen importlib._bootstrap_external>", line 1115, in _get_spec

[2021-02-03T11:02:09.235Z]   File "<frozen importlib._bootstrap_external>", line 1096, in _legacy_get_spec

[2021-02-03T11:02:09.235Z]   File "<frozen importlib._bootstrap>", line 444, in spec_from_loader

[2021-02-03T11:02:09.235Z]   File "<frozen importlib._bootstrap_external>", line 533, in spec_from_file_location

[2021-02-03T11:02:09.235Z]   File "/tmp/tmp8bmb1a6o/pip.zip/pip/_internal/cli/main.py", line 60

[2021-02-03T11:02:09.235Z]     sys.stderr.write(f"ERROR: {exc}")

[2021-02-03T11:02:09.235Z]                                    ^

[2021-02-03T11:02:09.235Z] SyntaxError: invalid syntax

[2021-02-03T11:02:09.799Z] Makefile:42: recipe for target '_itest-ubuntu-xenial' failed

[2021-02-03T11:02:09.799Z] make: *** [_itest-ubuntu-xenial] Error 1

```

`make test; make itest` pass locally.  Travis is going to take forever (more like days) to complete.