### PR TITLE
Build for and from Jammy image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
           - itest_xenial
           - itest_bionic
           - itest_focal
+          - itest_jammy
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 RUN apt-get update  \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ itest: $(ITEST_TARGETS)
 itest_xenial: _itest-ubuntu-xenial
 itest_bionic: _itest-ubuntu-bionic
 itest_focal: _itest-ubuntu-focal
+itest_jammy: _itest-ubuntu-jammy
 
 _itest-%: builddeb-docker
 	$(DOCKER_RUN_TEST) $(shell sed 's/-/:/' <<< "$*") /mnt/ci/docker


### PR DESCRIPTION
## Problem or Feature

We need Aactivator to be built for Jammy in order to run docker containers that use aactivator from a Jammy base.

## Solution

I added itest_jammy to the CI config and makefile...I don't think it does anything though.

I made the dockerfile source from a Jammy base instead, which confirms to me it works


## Testing

Testing status checks
