### PR TITLE
fix setup to allow to pass tests in internal jenkins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
           - test
           - itest_focal
           - itest_jammy
+          - itest_noble
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py37,py38,py39,py310,py311
+skip_missing_interpreters = true
 
 [testenv]
 deps = -rrequirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py37,py38,py39,py310,py311
 skip_missing_interpreters = true
 
 [testenv]
+passenv = TMP
 deps = -rrequirements-dev.txt
 commands =
     coverage erase


### PR DESCRIPTION
There's two issues that need dealing with:
1) There's interpreters in the tox.ini which don't exist internally, so we need to skip them. Luckily, this is a builtin tox feature.
2) The default tempdir fails the security_check requirements. We can set it to something else, but we need the test environment to respect that. So I added `passenv = TMP`

As a bonus, I also added `itest_noble` to the GHA tests